### PR TITLE
:bug: action trigger on manuel release on GitHub UI

### DIFF
--- a/.github/workflows/ch07-packaging.yml
+++ b/.github/workflows/ch07-packaging.yml
@@ -2,6 +2,7 @@ name: Packaging (chapter 7)
 
 on:
   - push
+  - release
 
 jobs:
   format:

--- a/.github/workflows/ch08-packaging.yml
+++ b/.github/workflows/ch08-packaging.yml
@@ -2,6 +2,7 @@ name: Packaging (chapter 8)
 
 on:
   - push
+  - release
 
 jobs:
   format:


### PR DESCRIPTION
- workflow was not triggered if the instruction on p. 124f were followed

## Description of issue

Following the instructions in the book, 
the GitHub actions were not triggered.

## Description of solution

Add release triggers as described here:
https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#release
